### PR TITLE
visual & merger

### DIFF
--- a/cyaron/__init__.py
+++ b/cyaron/__init__.py
@@ -15,4 +15,6 @@ from .vector import Vector
 from .polygon import Polygon
 from .compare import Compare
 from .math import *
+from .merger import Merger
+from .visual import visualize
 from random import randint, randrange, uniform, choice, random

--- a/cyaron/merger.py
+++ b/cyaron/merger.py
@@ -1,0 +1,54 @@
+from .graph import *
+
+class Merger:
+    def __init__(self, *graphs, **kwargs):
+        """__init__(self, *graphs, **kwargs) -> None
+            put several graphs into one
+            list graphs -> the graphs that will be merged
+            list kwargs:
+                None
+        """
+        self.graphs = graphs
+        self.G = Graph(sum([len(i.edges) - 1 for i in graphs]), graphs[0].directed)
+    
+        counter = 0 
+        for graph in self.graphs:
+            graph.offset = counter
+            for edge in graph.iterate_edges():
+                self.G.add_edge(edge.start + counter, 
+                                edge.end + counter, 
+                                weight=edge.weight)
+            counter += len(graph.edges) - 1
+
+    def add_edge(self, u, v, **kwargs):
+        """add_edge(self, u, v, **kwargs)
+            tuple u -> (graph_index, vertex) indicating the start point
+            tuple v -> (graph_index, vertex) indicating the end point
+            **kwargs:
+                int weight -> edge weight
+        """
+        self.G.add_edge(self.graphs[ u[0] ].offset + u[1],
+                        self.graphs[ v[0] ].offset + v[1], 
+                        weight=kwargs.get("weight", 1)) 
+
+    def result(self):
+        return self.G
+
+    @staticmethod
+    def component(point_count, edge_count, **kwargs):
+        """component(point_count, edge_count, **kwargs)
+            generate a graph with certain components
+            int point_count -> the number of vertices of each component
+            int edge_count -> the number of edges of each component
+            **kwargs:
+                int component_count -> indicating how many components there are
+        """
+        component_count = kwargs.get("component_count", (2, 2))
+        if not list_like(component_count):
+            component_count = (component_count, component_count)
+        real_count = random.randint(*component_count)
+        graphs = [None] * real_count
+        for i in xrange(real_count):
+            graphs[i] = Graph.graph(point_count, edge_count, **kwargs)
+        G = Merger(*graphs)
+        return G.result() 

--- a/cyaron/merger.py
+++ b/cyaron/merger.py
@@ -20,8 +20,8 @@ class Merger:
                                 weight=edge.weight)
             counter += len(graph.edges) - 1
 
-    def add_edge(self, u, v, **kwargs):
-        """add_edge(self, u, v, **kwargs)
+    def __add_edge(self, u, v, **kwargs):
+        """__add_edge(self, u, v, **kwargs)
             tuple u -> (graph_index, vertex) indicating the start point
             tuple v -> (graph_index, vertex) indicating the end point
             **kwargs:
@@ -30,6 +30,11 @@ class Merger:
         self.G.add_edge(self.graphs[ u[0] ].offset + u[1],
                         self.graphs[ v[0] ].offset + v[1], 
                         weight=kwargs.get("weight", 1)) 
+    
+    def add_edge(self, u, v, **kwargs):
+        """add_edge(self, u, v, **kwargs) -> None
+        """
+        self.__add_edge(u, v, **kwargs)
 
     def to_str(self, **kwargs):
         return self.G.to_str(**kwargs)

--- a/cyaron/merger.py
+++ b/cyaron/merger.py
@@ -31,8 +31,11 @@ class Merger:
                         self.graphs[ v[0] ].offset + v[1], 
                         weight=kwargs.get("weight", 1)) 
 
-    def result(self):
-        return self.G
+    def to_str(self, **kwargs):
+        return self.G.to_str(**kwargs)
+    
+    def __str__(self):
+        return self.to_str()
 
     @staticmethod
     def component(point_count, edge_count, **kwargs):
@@ -51,4 +54,4 @@ class Merger:
         for i in xrange(real_count):
             graphs[i] = Graph.graph(point_count, edge_count, **kwargs)
         G = Merger(*graphs)
-        return G.result() 
+        return G.G

--- a/cyaron/visual.py
+++ b/cyaron/visual.py
@@ -1,13 +1,14 @@
 from .graph import * 
+from .merger import Merger
 import pygraphviz as pgv
 
-def visualize(graph, **kwargs):
+def visualize(graph, output_path="a.png"):
     """visualize(graph, **kwargs) -> None
-        Graph graph -> the graph that will be visualized
-        **kwargs(Keyword args):
-            string outptu_file -> the path of the image
+        Graph/Merger graph -> the graph/Merger that will be visualized
+        string output_path-> the output path of the image
     """
-    output_file = kwargs.get("output_file", "a.png")
+
+    if isinstance(graph, Merger): graph = Merger.G
     G = pgv.AGraph(directed=graph.directed)
 
     G.add_nodes_from([i for i in xrange(1, len(graph.edges))])
@@ -20,6 +21,6 @@ def visualize(graph, **kwargs):
     G.edge_attr['arrowhead'] = 'open'
 
     G.layout(prog='dot')
-    G.draw(output_file)
+    G.draw(output_path)
     
 

--- a/cyaron/visual.py
+++ b/cyaron/visual.py
@@ -1,0 +1,25 @@
+from .graph import * 
+import pygraphviz as pgv
+
+def visualize(graph, **kwargs):
+    """visualize(graph, **kwargs) -> None
+        Graph graph -> the graph that will be visualized
+        **kwargs(Keyword args):
+            string outptu_file -> the path of the image
+    """
+    output_file = kwargs.get("output_file", "a.png")
+    G = pgv.AGraph(directed=graph.directed)
+
+    G.add_nodes_from([i for i in xrange(1, len(graph.edges))])
+    for edge in graph.iterate_edges():
+        G.add_edge(edge.start, edge.end, label=edge.weight)
+        
+    G.node_attr['shape'] = 'egg'
+    G.node_attr['width'] = '0.25'
+    G.node_attr['height'] = '0.25'
+    G.edge_attr['arrowhead'] = 'open'
+
+    G.layout(prog='dot')
+    G.draw(output_file)
+    
+


### PR DESCRIPTION
天啦噜我一直想写这种项目然后就发现你们这个repo了. 

然后我把源码看了一遍哇.

我第一反应就是添加一个可视化的功能就会很棒棒, 所以用pygraphviz写了一个visual.py. 最后出来的图大概就这样:
![多连通分量-multiple Components](http://image.jiantuku.com/17-6-3/27890793.jpg?attname=%E6%90%9C%E7%8B%97%E6%88%AA%E5%9B%BE20170603042442.png&e=1496480410&token=el7kgPgYzpJoB23jrChWJ2gV3HpRl0VCzFn8rKKv:FBBh-C0wHAVGTGmLEiW4oBrd2I4=)

然后这里的Graph类, 使用的是一开始就开辟了保存点的空间, 然后用index表示点. 因此 subgraph 的概念就几乎没有了. 在不修改已有代码的基础上, 我试着添加了一个Merger类, 用来合并多个Graph, 并支持在多个Graph之间连边. 

一个十分简单的应用就是, 我能够控制生成出来的图的连通分量的个数. 在merger.py里面有一个component用于生成指定联通分量个数的图. 

哇超感动的能看见这个repo. 