### PR TITLE
Fix filename bug

### DIFF
--- a/cyaron/io.py
+++ b/cyaron/io.py
@@ -72,7 +72,7 @@ class IO(object):
                 self.__output_temp = True
         else:
             # consider ``f`` as filename template
-            filename = f.format(data_id)
+            filename = f.format(data_id or '')
             if file_type == 'i':
                 self.input_filename = filename
                 log.debug("Processing %s" % self.input_filename)


### PR DESCRIPTION
Fix bug:
In IO.\_\_init\_\_, if file_prefix is set but data_id is `None`, filename will be formatted like `{file_prefix}None.in`.
Affects Python version (not all):
- Python 3.7.0
- PyPy 6.0.0