### PR TITLE
Make function ll_to_lt

### DIFF
--- a/cyaron/utils.py
+++ b/cyaron/utils.py
@@ -62,3 +62,8 @@ def unpack_kwargs(funcname, kwargs, arg_pattern):
     if kwargs:
         raise TypeError('{}() got an unexpected keyword argument \'{}\''.format(funcname, next(iter(kwargs.items()))[0]))
     return rv
+
+def ll_to_lt (l):
+    if not isinstance (l，list):
+        raise TypeError("L mast be a list")
+    return [tuple (i) for i in l]


### PR DESCRIPTION
增加了列表列表转元组列表的函数（`ll_to_lt`）
```python
print (ll_to_lt ([6,7],[8,9]))
```
```
[(6,7),(8,9)]
```