### PR TITLE
Fix test_noipstyle_incorrect failed on Windows

### DIFF
--- a/cyaron/tests/compare_test.py
+++ b/cyaron/tests/compare_test.py
@@ -44,8 +44,8 @@ class TestCompare(unittest.TestCase):
             io = IO("test_compare_incorrect.in", "test_compare_incorrect.out")
 
         io.output_writeln("test123 \ntest123\n")
-        with open("test_another_incorrect.out", "w") as f:
-            f.write("test123\r\ntest124 ")
+        with open("test_another_incorrect.out", "wb") as f:
+            f.write(b"test123\r\ntest124 ")
 
         try:
             with captured_output() as (out, err):


### PR DESCRIPTION
在 Windows 上运行 cyaron 测试，会出现如下错误：

```
======================================================================
FAIL: test_noipstyle_incorrect (cyaron.tests.compare_test.TestCompare)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "F:\Github\cyaron\cyaron\tests\compare_test.py", line 52, in test_noipstyle_incorrect
    Compare.output("test_another_incorrect.out", std=io)
cyaron.compare.CompareMismatch: In program: 'test_another_incorrect.out'. On line 2 column 7, read 4, expected 3.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "F:\Github\cyaron\cyaron\tests\compare_test.py", line 56, in test_noipstyle_incorrect
    self.assertEqual(e.content, 'test123\r\ntest124 ')
AssertionError: 'test123\r\r\ntest124 ' != 'test123\r\ntest124 '
+ test123
?         +
-
  test124
```

其原因是在 Windows 上的换行方式默认为 CRLF，以非二进制方式打开的文件中，写入的 `\n` 字符都将会被替换为 `\r\n` 字符。

https://github.com/luogu-dev/cyaron/blob/4c54f89265e7d4ed57fc7f7515b3befdcc474a07/cyaron/tests/compare_test.py#L32-L33

所以在测试用例中，写入 `test123\r\ntest124 ` 实际上会写入 `test123\r\r\ntest124 `。

修复方式为用二进制方式打开文件，再写入。