### PR TITLE
Fix: Vector.random 的 mode 参数不生效

### DIFF
--- a/cyaron/vector.py
+++ b/cyaron/vector.py
@@ -2,10 +2,10 @@
 
 from .utils import *
 import random
-from enum import Enum
+from enum import IntEnum
 
 
-class VectorRandomMode(Enum):
+class VectorRandomMode(IntEnum):
     unique = 0
     repeatable = 1
     float = 2


### PR DESCRIPTION
See: https://github.com/luogu-dev/cyaron/issues/109