### PR TITLE
add spanning tree

### DIFF
--- a/cyaron/graph.py
+++ b/cyaron/graph.py
@@ -110,6 +110,33 @@ class Graph:
         if not self.directed and x != y:
             self.__add_edge(y, x, weight)
 
+    def to_tree(self, root = 1, *, container = list):
+        """to_tree(self, root, *, container) -> list[tuple[int, int]]
+           Return a spanning tree of the graph.
+           By default, return the DFS spanning tree generated from node 1 as the root.
+           int root = 1 -> starting from `root` to generate.
+           container = list -> use list to simulate a stack by default.
+                               You can pass in a container class that implements `pop` and `append` methods.
+                               Additionally, it needs the method `__bool__` to indicate whether the container is non-empty.
+                               For example, pass in a heap to implement a minimum spanning tree.
+        """
+        tree = []
+        vis = set()
+        q = container()
+        q.append((0, root, 0))
+        while q:
+            _, u, fa = q.pop()
+            if u in vis:
+                continue
+            vis.add(u)
+            tree.append((fa, u))
+            for edge in self.edges[u]:
+                v, w = edge.end, edge.weight
+                if v in vis:
+                    continue
+                q.append((w, v, u))
+        return tree
+
     @staticmethod
     def chain(point_count, **kwargs):
         """chain(point_count, **kwargs) -> Graph

--- a/cyaron/graph.py
+++ b/cyaron/graph.py
@@ -129,7 +129,7 @@ class Graph:
         if not self.directed and x != y:
             self.__add_edge(y, x, weight)
 
-    def to_tree(self, root = 1, *, container = list):
+    def to_tree(self, root = 1, *, container = list, from_weight = lambda w: None):
         """to_tree(self, root, *, container) -> list[tuple[int, int]]
            Return a spanning tree of the graph.
            By default, return the DFS spanning tree generated from node 1 as the root.
@@ -138,6 +138,7 @@ class Graph:
                                You can pass in a container class that implements `pop` and `append` methods.
                                Additionally, it needs the method `__bool__` to indicate whether the container is non-empty.
                                For example, pass in a heap to implement a minimum spanning tree.
+           from_weight = lambda w: None -> use to print the weight of edge, if it returns `None`, the function will ignore the weight.
         """
         tree = []
         vis = set()
@@ -148,7 +149,8 @@ class Graph:
             if u in vis:
                 continue
             vis.add(u)
-            tree.append((fa, u))
+            w = from_weight(_)
+            tree.append((fa, u) if w is None else (fa, u, w))
             for edge in self.edges[u]:
                 v, w = edge.end, edge.weight
                 if v in vis:

--- a/cyaron/graph.py
+++ b/cyaron/graph.py
@@ -149,8 +149,9 @@ class Graph:
             if u in vis:
                 continue
             vis.add(u)
-            w = from_weight(_)
-            tree.append((fa, u) if w is None else (fa, u, w))
+            if fa != 0:
+                w = from_weight(_)
+                tree.append((fa, u) if w is None else (fa, u, w))
             for edge in self.edges[u]:
                 v, w = edge.end, edge.weight
                 if v in vis:


### PR DESCRIPTION
加入生成树，返回格式为（父，子）元组的列表

默认是从 `1` 开始执行 DFS（BFS 风格），可以通过指定容器实现 BFS 生成树或最小生成树。

可以通过传入 `from_weight` 决定是否显示边权和如何显示，默认是 `lambda w: None`，即不显示。

```python
import random
import heapq
import collections
from cyaron.graph import *

random.seed(0, 2)


class Queue:
    def __init__(self):
        self.queue = collections.deque()

    def append(self, _x):
        self.queue.append(_x)

    def pop(self):
        return self.queue.popleft()

    def __bool__(self):
        return bool(self.queue)


class Heap:
    def __init__(self):
        self.heap = []

    def append(self, _x):
        heapq.heappush(self.heap, _x)

    def pop(self):
        return heapq.heappop(self.heap)

    def __bool__(self):
        return bool(self.heap)


g = Graph.graph(6, 10, weight_limit=10)
print(g.to_str())
print(g.to_tree()) # DFS 生成树
print(g.to_tree(5)) # DFS 生成树, 以 5 为根
print(g.to_tree(container=Queue)) # BFS 生成树
print(g.to_tree(container=Heap)) # 最小生成树
```

应该输出：

```
1 2 10
1 6 6
2 5 5
2 3 2
3 5 8
3 4 8
3 5 4
3 5 10
4 4 1
4 5 2
[(1, 6), (1, 2), (2, 3), (3, 5), (5, 4)]
[(5, 4), (4, 3), (3, 2), (2, 1), (1, 6)]
[(1, 2), (1, 6), (2, 5), (2, 3), (5, 4)]
[(1, 6), (1, 2), (2, 3), (3, 5), (5, 4)]
[(1, 6, 6), (1, 2, 10), (2, 3, 2), (3, 5, 4), (5, 4, 2)]
```