### PR TITLE
Fixed errors in Vector.random when generating floating-point vectors or vectors with repeated elements.

### DIFF
--- a/cyaron/tests/__init__.py
+++ b/cyaron/tests/__init__.py
@@ -4,3 +4,4 @@ from .str_test import TestString
 from .polygon_test import TestPolygon
 from .compare_test import TestCompare
 from .graph_test import TestGraph
+from .vector_test import TestVector

--- a/cyaron/tests/vector_test.py
+++ b/cyaron/tests/vector_test.py
@@ -1,0 +1,33 @@
+import unittest
+from cyaron.vector import *
+
+
+def has_duplicates(lst: list):
+    return len(lst) != len(set(lst))
+
+
+class TestVector(unittest.TestCase):
+    def test_unique_vector(self):
+        v = Vector.random(10**5, [10**6])
+        self.assertFalse(has_duplicates(list(map(lambda tp: tuple(tp), v))))
+        self.assertTrue(all(map(lambda v: 0 <= v[0] <= 10**6, v)))
+        v = Vector.random(1000, [(10**5, 10**6)])
+        self.assertTrue(all(map(lambda v: 10**5 <= v[0] <= 10**6, v)))
+        with self.assertRaises(
+            Exception,
+            msg="1st param is so large that CYaRon can not generate unique vectors",
+        ):
+            v = Vector.random(10**5, [10**4])
+
+    def test_repeatable_vector(self):
+        v = Vector.random(10**5 + 1, [10**5], VectorRandomMode.repeatable)
+        self.assertTrue(all(map(lambda v: 0 <= v[0] <= 10**5, v)))
+        self.assertTrue(has_duplicates(list(map(lambda tp: tuple(tp), v))))
+        v = Vector.random(1000, [(10**5, 10**6)], VectorRandomMode.repeatable)
+        self.assertTrue(all(map(lambda v: 10**5 <= v[0] <= 10**6, v)))
+
+    def test_float_vector(self):
+        v = Vector.random(10**5, [10**5], VectorRandomMode.float)
+        self.assertTrue(all(map(lambda v: 0 <= v[0] <= 10**5, v)))
+        v = Vector.random(10**5, [(24, 25)], VectorRandomMode.float)
+        self.assertTrue(all(map(lambda v: 24 <= v[0] <= 25, v)))

--- a/cyaron/vector.py
+++ b/cyaron/vector.py
@@ -54,9 +54,9 @@ class Vector:
 
         result = []
         if mode == VectorRandomMode.repeatable:
-            result = [[random.randint(x, y) for x, y in zip(offset, length)] for _ in range(num)]
+            result = [[random.randint(x, x + y) for x, y in zip(offset, length)] for _ in range(num)]
         elif mode == VectorRandomMode.float:
-            result = [[random.uniform(x, y) for x, y in zip(offset, length)] for _ in range(num)]
+            result = [[random.uniform(x, x + y) for x, y in zip(offset, length)] for _ in range(num)]
         elif mode == VectorRandomMode.unique and vector_space > 5 * num:
             # O(NlogN)
             num_set = set()


### PR DESCRIPTION
https://github.com/luogu-dev/cyaron/issues/140

没写 Test 导致的，~~但是好像也不太好写。~~

EDITED: 加入了 vector_test