### PR TITLE
Support outputting high-dimensional lists

### DIFF
--- a/cyaron/io.py
+++ b/cyaron/io.py
@@ -200,6 +200,26 @@ class IO:
                 if arg == "\n":
                     self.is_first_char[file] = True
 
+    def __write_list(self, file: IOBase, *args, **kwargs):
+        separators = kwargs.get("separator", " ")
+        if list_like(separators):
+            if len(separators) == 0:
+                raise ValueError()
+            separator = make_unicode(separators[0])
+            separators = separators[1:]
+        else:
+            separator = separators = make_unicode(separators)
+        for arg in args:
+            if arg != "\n" and not self.is_first_char.get(file, True):
+                file.write(separator)
+            if list_like(arg):
+                self.__write_list(file, *arg, separator=separators)
+            else:
+                self.is_first_char[file] = False
+                file.write(make_unicode(arg))
+                if arg == "\n":
+                    self.is_first_char[file] = True
+
     def __clear(self, file: IOBase, pos: int = 0):
         """
         Clear the content use truncate()
@@ -233,6 +253,12 @@ class IO:
         args = list(args)
         args.append("\n")
         self.input_write(*args, **kwargs)
+
+    def input_write_list(self, *args, **kwargs):
+        self.__write_list(self.input_file, *args, **kwargs)
+
+    def input_write_listln(self, *args, **kwargs):
+        self.input_write_list(*args, "\n", **kwargs)
 
     def input_clear_content(self, pos: int = 0):
         """
@@ -302,6 +328,12 @@ class IO:
         args = list(args)
         args.append("\n")
         self.output_write(*args, **kwargs)
+
+    def output_write_list(self, *args, **kwargs):
+        self.__write_list(self.output_file, *args, **kwargs)
+
+    def output_write_listln(self, *args, **kwargs):
+        self.output_write_list(*args, "\n", **kwargs)
 
     def output_clear_content(self, pos: int = 0):
         """

--- a/cyaron/io.py
+++ b/cyaron/io.py
@@ -3,6 +3,7 @@ A module that provides a class IO to process the input and output files.
 Classes:
     IO: IO tool class. It will process the input and output files.
 """
+
 from __future__ import absolute_import
 import os
 import re
@@ -201,6 +202,10 @@ class IO:
                     self.is_first_char[file] = True
 
     def __write_list(self, file: IOBase, *args, **kwargs):
+        """
+        Write every element in *args into file. If the element isn't "\n", insert `separator`.
+        It will convert every element into str.
+        """
         separators = kwargs.get("separator", " ")
         if list_like(separators):
             if len(separators) == 0:
@@ -255,9 +260,26 @@ class IO:
         self.input_write(*args, **kwargs)
 
     def input_write_list(self, *args, **kwargs):
+        """
+        Write hith-dimensional lists in *args into the input file. Splits with `separator`.
+        It will convert every element into str.
+        Args:
+            *args: hith-dimensional lists to write
+            separator: a string or a string list used to separate every element in different
+                       dimension. Defaults to " ".
+        """
         self.__write_list(self.input_file, *args, **kwargs)
 
     def input_write_listln(self, *args, **kwargs):
+        """
+        Write hith-dimensional lists in *args into the input file and turn into a new line
+        Splits with `separator`.
+        It will convert every element into str.
+        Args:
+            *args: hith-dimensional lists to write
+            separator: a string or a string list used to separate every element in different
+                       dimension. Defaults to " ".
+        """
         self.input_write_list(*args, "\n", **kwargs)
 
     def input_clear_content(self, pos: int = 0):
@@ -330,9 +352,26 @@ class IO:
         self.output_write(*args, **kwargs)
 
     def output_write_list(self, *args, **kwargs):
+        """
+        Write hith-dimensional lists in *args into the output file. Splits with `separator`.
+        It will convert every element into str.
+        Args:
+            *args: hith-dimensional lists to write
+            separator: a string or a string list used to separate every element in different
+                       dimension. Defaults to " ".
+        """
         self.__write_list(self.output_file, *args, **kwargs)
 
     def output_write_listln(self, *args, **kwargs):
+        """
+        Write hith-dimensional lists in *args into the output file and turn into a new line
+        Splits with `separator`.
+        It will convert every element into str.
+        Args:
+            *args: hith-dimensional lists to write
+            separator: a string or a string list used to separate every element in different
+                       dimension. Defaults to " ".
+        """
         self.output_write_list(*args, "\n", **kwargs)
 
     def output_clear_content(self, pos: int = 0):


### PR DESCRIPTION
增加输出高维列表：

```python
from cyaron import IO

table = [['#', 'S', '.', '.', '#'], ['#', '#', '#', '.', '#'],
         ['#', '.', '#', '.', '#'], ['#', 'T', '#', '.', '#'],
         ['#', '.', '.', '.', '#']]

f = IO('test.in', disable_output=True)
f.input_write_list(table, separator=['', '\n', ''])
```

运行后 `test.in` 文件中：

```
#S..#
###.#
#.#.#
#T#.#
#...#
```

或者，将 `separator` 改为 `['', '\n', ' ']`：

```
# S . . #
# # # . #
# . # . #
# T # . #
# . . . #
```