### PR TITLE
增加在指定范围内随机质数的功能

### DIFF
--- a/cyaron/math.py
+++ b/cyaron/math.py
@@ -549,3 +549,94 @@ def n2words(num: int, join: bool = True):
     if join:
         return ' '.join(words)
     return words
+
+
+def nextprime(n: int):
+    """
+    Find the next prime number after a given number.
+    Args:
+        n: The number after which to find the next prime.
+    Returns:
+        The next prime number after n.
+    """
+
+    if n < 2:
+        return 2
+    if n == 2:
+        return 3
+    if n % 6 == 0:
+        if miller_rabin(n + 1):
+            return n + 1
+        n += 6
+    elif 1 <= n % 6 < 5:
+        n += 6 - n % 6
+    else:
+        if miller_rabin(n + 2):
+            return n + 2
+        n += 7
+    while True:
+        if miller_rabin(n - 1):
+            return n - 1
+        if miller_rabin(n + 1):
+            return n + 1
+        n += 6
+
+
+def prevprime(n: int, raise_error: bool = True):
+    """
+    Find the previous prime number before a given number.
+    Args:
+        n: The number before which to find the previous prime.
+        raise_error: Raise an error if there is no prime number less than `n`. Default is True.
+    Returns:
+        The previous prime number before `n`.
+    Raises:
+        ValueError: If there is no prime number less than `n` and `raise_error` is True.
+    """
+    if n <= 2:
+        if raise_error:
+            raise ValueError(f"No prime number less than {n}")
+        return 0
+    if n == 3:
+        return 2
+    if n <= 5:
+        return 3
+    if n % 6 == 0:
+        if miller_rabin(n - 1):
+            return n - 1
+        n -= 6
+    elif n % 6 == 1:
+        if miller_rabin(n - 2):
+            return n - 2
+        n -= 7
+    else:
+        n -= n % 6
+    while True:
+        if miller_rabin(n + 1):
+            return n + 1
+        if miller_rabin(n - 1):
+            return n - 1
+        n -= 6
+
+
+def randprime(a: int, b: int, raise_error: bool = True):
+    """
+    Generate a random prime number in the range [a, b].
+    Args:
+        a: The lower bound of the range.
+        b: The upper bound of the range.
+    Returns:
+        A random prime number in the specified range.
+    """
+    st = random.randint(a, b)
+    if miller_rabin(st):
+        return st
+    nxt = nextprime(st)
+    if nxt <= b:
+        return nxt
+    pre = prevprime(st)
+    if pre >= a:
+        return pre
+    if raise_error:
+        raise ValueError(f"No prime number in the range [{a}, {b}]")
+    return 0


### PR DESCRIPTION
算法不保证均匀随机，如果追求区间内每个质数被选中的概率相等，可以使用 `prime_sieve` 预处理质数表再使用 `random` 库中的 `choice` 函数。

具体流程如下：

1. 在区间内随机一个数字；
2. 判断这个数是否是质数，若是则立即返回；
3. 寻找这个数字的下一个质数，若在范围内则立即返回；
4. 寻找这个数字的上一个质数，若在范围内则立即返回；
5. 范围内没有质数，报告错误。

我为此实现的 `nextprime` 和 `prevprime` 都未经严格测试，大家可以先 review 一下（使用了大于 $3$ 的质数都是 $6n\pm 1$ 型的定理，逻辑略复杂）。

测试还没写，一会补上。