### PR TITLE
Fix: Ensure the path format is correct

### DIFF
--- a/cyaron/tests/compare_test.py
+++ b/cyaron/tests/compare_test.py
@@ -83,13 +83,13 @@ class TestCompare(unittest.TestCase):
 
         try:
             with captured_output() as (out, err):
-                Compare.program(f"{sys.executable} correct.py",
-                                f"{sys.executable} incorrect.py",
+                Compare.program(f"\"{sys.executable}\" correct.py",
+                                f"\"{sys.executable}\" incorrect.py",
                                 std=io,
                                 input=io,
                                 grader="FullText")
         except CompareMismatch as e:
-            self.assertEqual(e.name, f'{sys.executable} incorrect.py')
+            self.assertEqual(e.name, f'\"{sys.executable}\" incorrect.py')
             e = e.mismatch
             self.assertEqual(e.content, '2\n')
             self.assertEqual(e.std, '1\n')
@@ -105,7 +105,7 @@ class TestCompare(unittest.TestCase):
             self.assertTrue(False)
 
         result = out.getvalue().strip()
-        correct_out = f'{sys.executable} correct.py: Correct \n{sys.executable} incorrect.py: !!!INCORRECT!!! Hash mismatch: read 53c234e5e8472b6ac51c1ae1cab3fe06fad053beb8ebfd8977b010655bfdd3c3, expected 4355a46b19d348dc2f57c046f8ef63d4538ebb936000f3c9ee954a27460dd865'
+        correct_out = f'\"{sys.executable}\" correct.py: Correct \n\"{sys.executable}\" incorrect.py: !!!INCORRECT!!! Hash mismatch: read 53c234e5e8472b6ac51c1ae1cab3fe06fad053beb8ebfd8977b010655bfdd3c3, expected 4355a46b19d348dc2f57c046f8ef63d4538ebb936000f3c9ee954a27460dd865'
         self.assertEqual(result, correct_out)
 
     def test_file_input(self):
@@ -122,13 +122,13 @@ class TestCompare(unittest.TestCase):
         io.input_writeln("233")
 
         with captured_output() as (out, err):
-            Compare.program(f"{sys.executable} correct.py",
-                            std_program=f"{sys.executable} std.py",
+            Compare.program(f"\"{sys.executable}\" correct.py",
+                            std_program=f"\"{sys.executable}\" std.py",
                             input=io,
                             grader="NOIPStyle")
 
         result = out.getvalue().strip()
-        correct_out = f'{sys.executable} correct.py: Correct'
+        correct_out = f'\"{sys.executable}\" correct.py: Correct'
         self.assertEqual(result, correct_out)
 
     def test_concurrent(self):

--- a/cyaron/tests/io_test.py
+++ b/cyaron/tests/io_test.py
@@ -92,7 +92,7 @@ class TestIO(unittest.TestCase):
                 abs_input_filename: str = os.path.abspath(input_filename)
                 with self.assertRaises(subprocess.TimeoutExpired):
                     test.input_writeln(abs_input_filename)
-                    test.output_gen(f'"{sys.executable}" long_time.py',
+                    test.output_gen(f'\"{sys.executable}\" long_time.py',
                                     time_limit=TIMEOUT)
                 time.sleep(WAIT_TIME)
                 try:
@@ -108,7 +108,7 @@ class TestIO(unittest.TestCase):
                         "print(1)")
 
             with IO("test_gen.in", "test_gen.out") as test:
-                test.output_gen(f'"{sys.executable}" short_time.py',
+                test.output_gen(f'\"{sys.executable}\" short_time.py',
                                 time_limit=0.5)
         with open("test_gen.out", encoding="utf-8") as f:
             output = f.read()


### PR DESCRIPTION
将 `{sys.executable}` 替换为 `\"{sys.executable}\"`，保证路径格式正确。